### PR TITLE
Declare json_validation_rhino dependency

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,6 +29,7 @@ object Deps {
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin_reflect}"
     const val java_cose = "com.augustcellars.cose:cose-java:${Versions.java_cose}"
     const val json_validation = "com.github.fge:json-schema-validator:${Versions.json_validation}"
+    const val json_validation_rhino = "io.apisense:rhino-android:${Versions.json_validation_rhino}"
     const val jackson_cbor = "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${Versions.jackson_cbor}"
     const val bouncy_castle = "org.bouncycastle:bcpkix-jdk15to18:${Versions.bouncy_castle}"
 

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -34,6 +34,7 @@ object Versions {
 
     // Validation
     const val json_validation = "2.2.6"
+    const val json_validation_rhino = "1.0"
 
     // Tests
     const val junit = "4.13.1"


### PR DESCRIPTION
Fix for #24 

I copied the declaration from the [dgca-verifier-app-android][1] repository

[1]: https://github.com/eu-digital-green-certificates/dgca-verifier-app-android/blob/main/buildSrc/src/main/java/Dependencies.kt