### PR TITLE
Lower minSdk to 21

### DIFF
--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -23,7 +23,7 @@
 import org.gradle.api.JavaVersion
 
 object Config {
-    const val minSdk = 26
+    const val minSdk = 21
     const val compileSdk = 29
     const val targetSdk = 29
     val javaVersion = JavaVersion.VERSION_1_8

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -24,6 +24,7 @@ object Deps {
 
     const val tools_gradle_android = "com.android.tools.build:gradle:${Versions.gradle}"
     const val tools_kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
+    const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:${Versions.desugar_jdk_libs}"
 
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin_reflect}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -25,6 +25,7 @@ object Versions {
     // Base
     const val gradle = "4.1.3"
     const val kotlin = "1.4.32"
+    const val desugar_jdk_libs = "1.1.5"
 
     // Decoder
     const val kotlin_reflect = "1.4.32"

--- a/decoder/build.gradle
+++ b/decoder/build.gradle
@@ -24,6 +24,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled = true
         sourceCompatibility Config.javaVersion
         targetCompatibility Config.javaVersion
     }
@@ -41,6 +42,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring Deps.desugar_jdk_libs
+    
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_reflect
     implementation Deps.java_cose

--- a/decoder/src/main/java/dgca/verifier/app/decoder/Extensions.kt
+++ b/decoder/src/main/java/dgca/verifier/app/decoder/Extensions.kt
@@ -22,6 +22,7 @@
 
 package dgca.verifier.app.decoder
 
+import android.util.Base64
 import com.upokecenter.cbor.CBORObject
 import dgca.verifier.app.decoder.model.KeyPairData
 import java.io.ByteArrayInputStream
@@ -29,12 +30,11 @@ import java.security.KeyPairGenerator
 import java.security.MessageDigest
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
-import java.util.Base64
 
 const val ECDSA_256 = -7
 const val RSA_PSS_256 = -37
 
-fun ByteArray.toBase64(): String = Base64.getEncoder().encodeToString(this)
+fun ByteArray.toBase64(): String = Base64.encodeToString(this, Base64.NO_WRAP)
 
 fun ByteArray.toHexString(): String = joinToString("") { "%02x".format(it) }
 
@@ -42,10 +42,10 @@ fun String.hexToByteArray(): ByteArray = chunked(2)
     .map { it.toInt(16).toByte() }
     .toByteArray()
 
-fun String.fromBase64(): ByteArray = Base64.getDecoder().decode(this)
+fun String.fromBase64(): ByteArray = Base64.decode(this, Base64.NO_WRAP)
 
 fun String.base64ToX509Certificate(): X509Certificate? {
-    val decoded = Base64.getDecoder().decode(this)
+    val decoded = Base64.decode(this, Base64.NO_WRAP)
     val inputStream = ByteArrayInputStream(decoded)
 
     return CertificateFactory.getInstance("X.509").generateCertificate(inputStream) as? X509Certificate

--- a/decoder/src/main/java/dgca/verifier/app/decoder/Util.kt
+++ b/decoder/src/main/java/dgca/verifier/app/decoder/Util.kt
@@ -22,10 +22,10 @@
 
 package dgca.verifier.app.decoder
 
+import android.util.Base64
 import java.nio.charset.StandardCharsets
 import java.security.PrivateKey
 import java.security.Signature
-import java.util.Base64
 
 fun generateClaimSignature(
     tanHash: String,
@@ -42,5 +42,5 @@ fun generateClaimSignature(
     signature.update(sigValue.toString().toByteArray(StandardCharsets.UTF_8))
     val sigData = signature.sign()
 
-    return Base64.getEncoder().encodeToString(sigData)
+    return Base64.encodeToString(sigData, Base64.NO_WRAP)
 }


### PR DESCRIPTION
Hey, could it be possible to lower the `minSdk` to API 21? In our French app we still have a lot of users under API 26. Thank you.

Changes:
- Enable `coreLibraryDesugaringEnabled` to use java time
- Use `Base64` from android util package instead of `Base64` from java util package