### PR TITLE
Remove useless dependency to rhino

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,6 @@ object Deps {
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin_reflect}"
     const val java_cose = "com.augustcellars.cose:cose-java:${Versions.java_cose}"
     const val json_validation = "com.github.fge:json-schema-validator:${Versions.json_validation}"
-    const val json_validation_rhino = "io.apisense:rhino-android:${Versions.json_validation_rhino}"
     const val jackson_cbor = "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${Versions.jackson_cbor}"
     const val bouncy_castle = "org.bouncycastle:bcpkix-jdk15to18:${Versions.bouncy_castle}"
 

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -35,7 +35,6 @@ object Versions {
 
     // Validation
     const val json_validation = "2.2.6"
-    const val json_validation_rhino = "1.0"
 
     // Tests
     const val junit = "4.13.1"

--- a/decoder/build.gradle
+++ b/decoder/build.gradle
@@ -43,12 +43,13 @@ android {
 
 dependencies {
     coreLibraryDesugaring Deps.desugar_jdk_libs
-    
+
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_reflect
     implementation Deps.java_cose
-    implementation Deps.json_validation
-    implementation Deps.json_validation_rhino
+    implementation(Deps.json_validation) {
+        exclude group: "org.mozilla", module: "rhino"
+    }
     implementation Deps.jackson_cbor
     implementation Deps.bouncy_castle
 


### PR DESCRIPTION
## Describe the improvement
The project is dependent on the Rhino lib but it doesn't seem to be used

## Expected behaviour
The lib should import as little lib as possible

## Content of this PR
Remove the Rhino dependency

## How did you test?

Clone repo
Open in Android Studio
Run unit tests ✅